### PR TITLE
Update indexing pipeline for fondant==0.8.dev2 with new dataset format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fondant==0.7.0
+fondant==0.8.dev2
 notebook==7.0.6

--- a/src/components/load_from_hf_hub/fondant_component.yaml
+++ b/src/components/load_from_hf_hub/fondant_component.yaml
@@ -1,12 +1,10 @@
 name: Load from huggingface hub
 description: Component that loads a dataset from huggingface hub
-image: fndnt/load_from_hf_hub:0.6.2
+image: fndnt/load_from_hf_hub:0.8.dev2
 
 produces:
   text:
-    fields:
-      data:
-        type: string
+    type: string
 
 args:
   dataset_name:

--- a/src/components/text_cleaning/fondant_component.yaml
+++ b/src/components/text_cleaning/fondant_component.yaml
@@ -3,13 +3,9 @@ description: Clean text passages
 image: ghcr.io/ml6team/text_cleaning:dev
 
 consumes:
-  text:
-    fields:
-      data:
-        type: string
+  text_data:
+    type: string
 
 produces:
-  text:
-    fields:
-      data:
-        type: string
+  text_data:
+    type: string

--- a/src/pipeline.ipynb
+++ b/src/pipeline.ipynb
@@ -132,13 +132,11 @@
     "%%writefile components/load_from_hf_hub/fondant_component.yaml\n",
     "name: Load from huggingface hub\n",
     "description: Component that loads a dataset from huggingface hub\n",
-    "image: fndnt/load_from_hf_hub:0.6.2\n",
+    "image: fndnt/load_from_hf_hub:0.8.dev2\n",
     "\n",
     "produces:\n",
     "  text:\n",
-    "    fields:\n",
-    "      data:\n",
-    "        type: string\n",
+    "    type: string\n",
     "\n",
     "args:\n",
     "  dataset_name:\n",
@@ -182,10 +180,6 @@
     "    arguments={\n",
     "        # Add arguments\n",
     "        \"dataset_name\": \"wikitext@~parquet\",\n",
-    "        # Define the column mapping between the huggingface dataset and the Fondant dataframe\n",
-    "        \"column_name_mapping\": {\n",
-    "            \"text\": \"text_data\"\n",
-    "        },\n",
     "        \"n_rows_to_load\": 100\n",
     "    }\n",
     ")\n",
@@ -328,7 +322,6 @@
     "run_explorer_app(\n",
     "    base_path=BASE_PATH,\n",
     "    container=\"fndnt/data_explorer\",\n",
-    "    tag=\"0.6.2\",\n",
     "    port=8501\n",
     ")"
    ]
@@ -375,16 +368,12 @@
     "image: ghcr.io/ml6team/text_cleaning:dev\n",
     "\n",
     "consumes:\n",
-    "  text:\n",
-    "    fields:\n",
-    "      data:\n",
-    "        type: string\n",
+    "  text_data:\n",
+    "    type: string\n",
     "\n",
     "produces:\n",
-    "  text:\n",
-    "    fields:\n",
-    "      data:\n",
-    "        type: string"
+    "  text_data:\n",
+    "    type: string"
    ]
   },
   {
@@ -478,7 +467,7 @@
    "outputs": [],
    "source": [
     "%%writefile components/text_cleaning/requirements.txt\n",
-    "fondant[component]==0.7.0"
+    "fondant[component]==0.8.dev2"
    ]
   },
   {
@@ -548,7 +537,6 @@
     "run_explorer_app(\n",
     "    base_path=BASE_PATH,\n",
     "    container=\"fndnt/data_explorer\",\n",
-    "    tag=\"latest\",\n",
     "    port=8501,\n",
     ")"
    ]

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -20,7 +20,7 @@ load_from_hf_hub = ComponentOp(
         # Add arguments
         "dataset_name": "wikitext@~parquet",
         "column_name_mapping": {"text": "text_data"},
-        "n_rows_to_load": 10,
+        "n_rows_to_load": 100,
     },
 )
 


### PR DESCRIPTION
This PR updates the indexing pipeline for the new dataset format in fondant==0.8.dev1.

I would not merge this until we have updated the data explorer as well.